### PR TITLE
Enable linting with type information

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,22 +4,28 @@ import tseslint from 'typescript-eslint';
 
 export default [
     js.configs.recommended,
-    ...tseslint.configs.strict,
-    ...tseslint.configs.stylistic,
+    ...tseslint.configs.strictTypeChecked,
+    ...tseslint.configs.stylisticTypeChecked,
 
+    {
+        ignores: [
+            ".eslintrc.config.js",
+            "jest.config.js",
+            "vite.config.js",
+            "**/*.spec.ts", // TODO: Remove me
+        ],
+    },
     {
         languageOptions: {
             globals: {
                 ...globals.browser,
                 ...globals.node,
-            }
+            },
+            parserOptions: {
+                projectService: true,
+                tsconfigRootDir: import.meta.dirname,
+            },
         },
-
-        ignores: [
-            ".eslintrc.config.js",
-            "jest.config.js",
-            "vite.config.js",
-        ],
 
         files: [
             '**/*.ts',
@@ -36,6 +42,7 @@ export default [
             "@typescript-eslint/no-inferrable-types": 0, // TODO
             "@typescript-eslint/no-non-null-assertion": 0,
             "@typescript-eslint/no-unused-vars": 0,
+            "@typescript-eslint/restrict-template-expressions": ["error", { "allowNumber": true }],
             "brace-style": ["error", "stroustrup"],
             indent: ["error", 4, {"SwitchCase": 1}],
             "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",

--- a/src/pacman.ts
+++ b/src/pacman.ts
@@ -8,14 +8,20 @@ import { LoadingState } from './pacman/LoadingState';
 const CANVAS_WIDTH: number = 224; //448;
 const CANVAS_HEIGHT: number = 288; //576;
 
-(window as any).init = function(parent: HTMLElement, assetRoot?: string) {
-    const gameWindow: any = window as any;
-    gameWindow.game = new PacmanGame({
+declare global {
+    interface Window {
+        game?: PacmanGame;
+        init: (parent: HTMLElement | string, assetRoot?: string) => void;
+    }
+}
+
+window.init = function(parent: HTMLElement | string, assetRoot?: string) {
+    window.game = new PacmanGame({
         parent: parent, width: CANVAS_WIDTH, height: CANVAS_HEIGHT,
         assetRoot: assetRoot, keyRefreshMillis: 300, targetFps: 60
     });
-    gameWindow.game.setState(new LoadingState());
-    gameWindow.game.start();
+    window.game.setState(new LoadingState());
+    window.game.start();
 };
-(window as any).init('parent');
+window.init('parent');
 

--- a/src/pacman/Ghost.ts
+++ b/src/pacman/Ghost.ts
@@ -7,8 +7,6 @@ import { MazeNode } from './MazeNode';
 import { Pacman } from './Pacman';
 import Constants from './Constants';
 
-declare let game: PacmanGame;
-
 const GHOST_IN_BOX_SPEED: number = 0.5;
 
 export enum MotionState {
@@ -69,7 +67,7 @@ export abstract class Ghost extends _BaseSprite {
      * The motion state to revert back to when a ghost leaves "blue mode."
      * If a ghost is not in "blue mode," this value is invalid.
      */
-    private previousState: number;
+    private previousState: MotionState;
 
     /**
      * The y-coordinate of the sprites in the sprite sheet to use.
@@ -392,7 +390,7 @@ export abstract class Ghost extends _BaseSprite {
                     }
                     break;
                 default:
-                    throw new Error('Unexpected state: ' + this._motionState);
+                    throw new Error(`Unexpected state: ${this._motionState}`);
             }
             this._motionState = motionState;
         }

--- a/src/pacman/MazeNode.ts
+++ b/src/pacman/MazeNode.ts
@@ -24,7 +24,7 @@ export class MazeNode {
     }
 
     toString() {
-        return '[MazeNode: (' + this.row + ',' + this.col + ')]';
+        return `[MazeNode: (${this.row},${this.col})]`;
     }
 
 }

--- a/src/pacman/MazeState.ts
+++ b/src/pacman/MazeState.ts
@@ -8,8 +8,6 @@ import { Ghost, MotionState } from './Ghost';
 import { InputManager, Keys } from 'gtp';
 import Constants from './Constants';
 
-declare let game: PacmanGame;
-
 type Substate = 'READY' | 'IN_GAME' | 'DYING' | 'GAME_OVER';
 
 export class MazeState extends _BaseState {

--- a/src/pacman/Pacman.ts
+++ b/src/pacman/Pacman.ts
@@ -5,8 +5,6 @@ import { InputManager } from 'gtp';
 import { PacmanGame } from './PacmanGame';
 import Constants from './Constants';
 
-declare let game: PacmanGame;
-
 export class Pacman extends _BaseSprite {
 
     _dyingFrame: number;

--- a/src/pacman/PacmanGame.ts
+++ b/src/pacman/PacmanGame.ts
@@ -10,6 +10,7 @@ import { Clyde } from './Clyde';
 import { MazeState } from './MazeState';
 import { Maze } from './Maze';
 import Constants from './Constants';
+import { GameArgs } from 'gtp/lib/gtp/Game';
 
 /**
  * The default high score displayed in the game.
@@ -83,7 +84,7 @@ export class PacmanGame extends Game {
 
     private _godMode: boolean;
 
-    constructor(args?: any) {
+    constructor(args?: GameArgs  & { desktopGame?: boolean }) {
         super(args);
         this.highScore = DEFAULT_HIGH_SCORE;
         this.pacman = new Pacman(this);
@@ -91,7 +92,7 @@ export class PacmanGame extends Game {
         this.chompSound = 0;
         this._ghostUpdateStrategy = GhostUpdateStrategy.UPDATE_ALL;
         this.score = 0; // For title screen
-        this.desktopGame = args?.desktopGame ? args.desktopGame : this._isRunningInElectron();
+        this.desktopGame = args?.desktopGame ?? this._isRunningInElectron();
 
         this.extraPointsArray = [100, 200, 300, 400, 500, 700, 800,
             1000, 1600, 2000, 3000, 5000];
@@ -480,7 +481,7 @@ export class PacmanGame extends Game {
 
     setStretchMode(stretchMode: StretchMode) {
         if (this.isDesktopGame()) {
-            this.setStatusMessage('Stretch mode: ' + this.stretchMode);
+            this.setStatusMessage(`Stretch mode: ${this.stretchMode}`);
             this.stretchMode = stretchMode;
             CanvasResizer.resize(this.canvas, this.stretchMode);
         }
@@ -492,9 +493,9 @@ export class PacmanGame extends Game {
         this.score = 0;
         this._level = 0;
 
-        const levelsData: any = this.assets.get('levels');
-        const levelData: any = levelsData[level];
-        const mazeState: any = new MazeState(levelData);
+        const levelsData: number[][][] = this.assets.get('levels');
+        const levelData = levelsData[level];
+        const mazeState = new MazeState(levelData);
         //this.setState(new FadeOutInState(this.state, mazeState));
         this.setState(mazeState); // The original did not fade in/out
     }

--- a/src/pacman/Sounds.ts
+++ b/src/pacman/Sounds.ts
@@ -2,7 +2,7 @@
  * Constants to use for keys in our assets.  We cannot use an enum since
  * TypeScript does not yet support enums of strings.
  */
-const SOUNDS: any = {
+const SOUNDS: Record<string, string> = {
     CHASING_GHOSTS: 'chasingGhosts',
     CHOMP_1: 'chomp1',
     CHOMP_2: 'chomp2',

--- a/src/pacman/TitleState.ts
+++ b/src/pacman/TitleState.ts
@@ -7,8 +7,6 @@ import SOUNDS from './Sounds';
 import { Game, Image, InputManager, SpriteSheet } from 'gtp';
 import Constants from './Constants';
 
-declare let game: PacmanGame;
-
 export class TitleState extends _BaseState {
 
     private choice: number;
@@ -23,15 +21,13 @@ export class TitleState extends _BaseState {
         // Initialize our sprites not just in enter() so they are positioned
         // correctly while FadeOutInState is running
         this._initSprites(args);
-
-        this.handleStart = this.handleStart.bind(this);
     }
 
     override enter(game: PacmanGame) {
         this.game = game;
         super.enter(game);
 
-        game.canvas.addEventListener('touchstart', this.handleStart, { capture: false, passive: true });
+        game.canvas.addEventListener('touchstart', this.handleStart.bind(this), { capture: false, passive: true });
         this.choice = 0;
         this.lastKeypressTime = game.playTime;
 
@@ -48,7 +44,7 @@ export class TitleState extends _BaseState {
     }
 
     override leaving(game: Game) {
-        game.canvas.removeEventListener('touchstart', this.handleStart, false);
+        game.canvas.removeEventListener('touchstart', this.handleStart.bind(this), false);
     }
 
     handleStart() {

--- a/src/pacman/_BaseSprite.ts
+++ b/src/pacman/_BaseSprite.ts
@@ -84,7 +84,7 @@ export abstract class _BaseSprite {
         const x: number = this.centerX;
         const y: number = this.centerY;
         if ((x % 1) !== 0 || (y % 1) !== 0) {
-            console.error('Unexpected condition: x === ' + x + ', y === ' + y);
+            console.error(`Unexpected condition: x === ${x}, y === ${y}`);
         }
         const xRemainder: number = x % this.TILE_SIZE;
         const yRemainder: number = y % this.TILE_SIZE; //(y-TILE_SIZE) % this.TILE_SIZE;

--- a/src/pacman/_BaseState.ts
+++ b/src/pacman/_BaseState.ts
@@ -1,8 +1,6 @@
 import { BaseStateArgs, InputManager, Keys, State, Utils } from 'gtp';
 import { PacmanGame } from './PacmanGame';
 
-declare let game: PacmanGame;
-
 export class _BaseState extends State<PacmanGame> {
 
     private _lastConfigKeypressTime: number;
@@ -44,13 +42,13 @@ export class _BaseState extends State<PacmanGame> {
                 if (im.isKeyDown(Keys.KEY_P, true)) {
                     const style: CSSStyleDeclaration = game.canvas.style;
                     if (!style.width) {
-                        style.width = game.canvas.width + 'px';
+                        style.width = `${game.canvas.width}px`;
                     }
                     if (!style.height) {
-                        style.height = game.canvas.height + 'px';
+                        style.height = `${game.canvas.height}px`;
                     }
-                    style.width = (parseInt(style.width.substring(0, style.width.length - 2), 10) + 1) + 'px';
-                    style.height = (parseInt(style.height.substring(0, style.height.length - 2), 10) + 1) + 'px';
+                    style.width = `${parseInt(style.width.substring(0, style.width.length - 2), 10) + 1}px`;
+                    style.height = `${parseInt(style.height.substring(0, style.height.length - 2), 10) + 1}px`;
                     game.setStatusMessage(`Canvas size now: (${style.width}, ${style.height})`);
                     this._lastConfigKeypressTime = time;
                 }
@@ -59,13 +57,13 @@ export class _BaseState extends State<PacmanGame> {
                 else if (im.isKeyDown(Keys.KEY_L, true)) {
                     const style: CSSStyleDeclaration = game.canvas.style;
                     if (!style.width) {
-                        style.width = game.canvas.width + 'px';
+                        style.width = `${game.canvas.width}px`;
                     }
                     if (!style.height) {
-                        style.height = game.canvas.height + 'px';
+                        style.height = `${game.canvas.height}px`;
                     }
-                    style.width = (parseInt(style.width.substring(0, style.width.length - 2), 10) - 1) + 'px';
-                    style.height = (parseInt(style.height.substring(0, style.height.length - 2), 10) - 1) + 'px';
+                    style.width = `${parseInt(style.width.substring(0, style.width.length - 2), 10) - 1}px`;
+                    style.height = `${parseInt(style.height.substring(0, style.height.length - 2), 10) - 1}px`;
                     game.setStatusMessage(`Canvas size now: (${style.width}, ${style.height})`);
                     this._lastConfigKeypressTime = time;
                 }


### PR DESCRIPTION
Like it says on the tin. Enable eslint linting with type information.

This is disabled for spec files for now as they have too many violations, so I'd like to clean them up separately.