### PR TITLE
chore: Simplify game startup code

### DIFF
--- a/src/pacman.ts
+++ b/src/pacman.ts
@@ -8,20 +8,10 @@ import { LoadingState } from './pacman/LoadingState';
 const CANVAS_WIDTH = 224; //448;
 const CANVAS_HEIGHT = 288; //576;
 
-declare global {
-    interface Window {
-        game?: PacmanGame;
-        init: (parent: HTMLElement | string, assetRoot?: string) => void;
-    }
-}
-
-window.init = function(parent: HTMLElement | string, assetRoot?: string) {
-    window.game = new PacmanGame({
-        parent: parent, width: CANVAS_WIDTH, height: CANVAS_HEIGHT,
-        assetRoot: assetRoot, keyRefreshMillis: 300, targetFps: 60,
-    });
-    window.game.setState(new LoadingState());
-    window.game.start();
-};
-window.init('parent');
+const game = new PacmanGame({
+    parent: 'parent', width: CANVAS_WIDTH, height: CANVAS_HEIGHT,
+    keyRefreshMillis: 300, targetFps: 60,
+});
+game.setState(new LoadingState(game));
+game.start();
 

--- a/src/pacman/LoadingState.spec.ts
+++ b/src/pacman/LoadingState.spec.ts
@@ -6,13 +6,13 @@ describe('LoadingState', () => {
 
     describe('update()', () => {
         it('Loads the "loading" image', () => {
-            const mockGame = new PacmanGame();
-            const loadingState = new LoadingState({ game: mockGame });
+            const game = new PacmanGame();
+            const loadingState = new LoadingState(game);
 
-            const addImageSpy = vi.spyOn(mockGame.assets, 'addImage');
-            const onLoadSpy = vi.spyOn(mockGame.assets, 'onLoad');
+            const addImageSpy = vi.spyOn(game.assets, 'addImage');
+            const onLoadSpy = vi.spyOn(game.assets, 'onLoad');
 
-            loadingState.enter(mockGame);
+            loadingState.enter(game);
             loadingState.update(16);
 
             expect(addImageSpy).toHaveBeenCalledWith('loading', 'res/loadingMessage.png');
@@ -20,24 +20,24 @@ describe('LoadingState', () => {
         });
 
         it('when the loading image is loaded, it loads other assets', () => {
-            const mockGame = new PacmanGame();
-            mockGame.assets.set('levels', [
+            const game = new PacmanGame();
+            game.assets.set('levels', [
                 [ [ 0, 1 ], [ 1, 0 ] ],
                 [ [ 1, 0 ], [ 0, 1 ] ],
             ]);
 
-            const addImageSpy = vi.spyOn(mockGame.assets, 'addImage');
-            const addSpriteSheetSpy = vi.spyOn(mockGame.assets, 'addSpriteSheet');
-            const addJsonSpy = vi.spyOn(mockGame.assets, 'addJson');
-            const addSoundSpy = vi.spyOn(mockGame.assets, 'addSound');
-            const setSpy = vi.spyOn(mockGame.assets, 'set');
+            const addImageSpy = vi.spyOn(game.assets, 'addImage');
+            const addSpriteSheetSpy = vi.spyOn(game.assets, 'addSpriteSheet');
+            const addJsonSpy = vi.spyOn(game.assets, 'addJson');
+            const addSoundSpy = vi.spyOn(game.assets, 'addSound');
+            const setSpy = vi.spyOn(game.assets, 'set');
 
-            vi.spyOn(mockGame.assets, 'onLoad').mockImplementation((callback) => {
+            vi.spyOn(game.assets, 'onLoad').mockImplementation((callback) => {
                 callback();
             });
 
-            const loadingState = new LoadingState({ game: mockGame });
-            loadingState.enter(mockGame);
+            const loadingState = new LoadingState(game);
+            loadingState.enter(game);
             loadingState.update(60);
 
             expect(addImageSpy).toHaveBeenCalledWith('title', 'res/title.png');

--- a/src/pacman/LoadingState.ts
+++ b/src/pacman/LoadingState.ts
@@ -1,4 +1,4 @@
-import { BaseStateArgs, FadeOutInState, Utils } from 'gtp';
+import { FadeOutInState, Utils } from 'gtp';
 import { BaseState } from './BaseState';
 import { SOUNDS } from './Sounds';
 import { PacmanGame } from './PacmanGame';
@@ -12,7 +12,7 @@ export class LoadingState extends BaseState {
     /**
      * State that renders while resources are loading.
      */
-    constructor(args?: PacmanGame | BaseStateArgs<PacmanGame>) {
+    constructor(args: PacmanGame) {
         super(args);
         this.assetsLoaded = false;
     }


### PR DESCRIPTION
This game code is ancient, and the main `pacman.js` was written as adding a function to be called on the page's `onload` event. The old way also required adding fields to `Window`, and so some TS interface extension shenanigans.

None of this is necessary anymore since the game and gtp are now modernized, and the code is loaded with `type="module"`.

Diff best viewed in "split" mode and with whitespace hidden